### PR TITLE
Setup CI for this repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,80 @@
+name: CI
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'cluster/**'
+      - 'zdo/**'
+    branches:
+      - master
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'cluster/**'
+      - 'zdo/**'
+    branches:
+      - master
+
+jobs:
+  generate_and_test:
+    name: Generate and test ZCL
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: zcl
+    - uses: actions/checkout@v2
+      with:
+        repository: hemtjanst/zyaml
+        path: zyaml
+    - uses: actions/setup-go@v2-beta
+      with:
+        go-version: '1.14'
+    - name: Generate ZCL
+      working-directory: ./zcl
+      run: |
+        go run hemtjan.st/zcl/cmd/zclgen -definition-path ../zyaml
+    - name: Build updated ZCL
+      working-directory: ./zcl
+      run: |
+        go build hemtjan.st/zcl/...
+    - name: Run ZCL tests
+      working-directory: ./zcl
+      run: |
+        go test -v hemtjan.st/zcl/...
+  update:
+    name: Push updated ZCL
+    if: github.ref == 'refs/heads/master'
+    needs: generate_and_test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: zcl
+        ssh-key: ${{ secrets.BOT_SSH_KEY }}
+    - uses: actions/checkout@v2
+      with:
+        repository: hemtjanst/zyaml
+        path: zyaml
+    - uses: actions/setup-go@v2-beta
+      with:
+        go-version: '1.14'
+    - name: Generate ZCL
+      working-directory: ./zcl
+      run: |
+        go run hemtjan.st/zcl/cmd/zclgen -definition-path ../zyaml
+        go build hemtjan.st/zcl/...
+        go mod tidy
+    - name: Commit
+      working-directory: ./zcl
+      run: |
+        git config user.name "Hemtjanst Bot"
+        git config user.email "63548820+hemtjanst-bot@users.noreply.github.com"
+        git add .
+        git commit -m "Regenerated library at ${GITHUB_SHA}"
+    - name: Push
+      working-directory: ./zcl
+      run: |
+        git push

--- a/.github/workflows/generated.yaml
+++ b/.github/workflows/generated.yaml
@@ -1,0 +1,16 @@
+name: Prevent generated code in PRs
+on:
+  pull_request:
+    paths:
+      - 'cluster/**'
+      - 'zdo/**'
+
+jobs:
+  error:
+    name: Includes generated code
+    runs-on: ubuntu-latest
+    steps:
+    - name: Exit
+      run: |
+        echo "Do not include generated code in your PRs"
+        exit 1


### PR DESCRIPTION
Two separate jobs:

* Regular CI, which on a PR generates, builds and tests and if it's
  a push or merge to master also commits/pushes the updated code.

  We explicitly avoid triggering CI on cluster/ and zdo/ so if a
  PR only contains those changes nothing will happen. When a
  push to master only contains those changes it won't rebuild,
  avoiding an endless cycle.

* A separate flow that only triggers for PRs that have generated
  code in them and always fails. Generated code should never be
  checked in, it'll be automatically generated and committed on
  a merge to master.