### PR TITLE
Fix Command ID conflict causing wrong direction to be set

### DIFF
--- a/cluster/general/0003_identify.go
+++ b/cluster/general/0003_identify.go
@@ -355,7 +355,7 @@ func (IdentifyQueryResponse) Required() bool { return true }
 func (IdentifyQueryResponse) Cluster() zcl.ClusterID { return IdentifyID }
 
 // Direction of the command
-func (IdentifyQueryResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (IdentifyQueryResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (IdentifyQueryResponse) MnfCode() uint16 { return 0 }

--- a/cluster/general/0004_groups.go
+++ b/cluster/general/0004_groups.go
@@ -679,7 +679,7 @@ func (AddGroupResponse) Required() bool { return true }
 func (AddGroupResponse) Cluster() zcl.ClusterID { return GroupsID }
 
 // Direction of the command
-func (AddGroupResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (AddGroupResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (AddGroupResponse) MnfCode() uint16 { return 0 }
@@ -795,7 +795,7 @@ func (ViewGroupResponse) Required() bool { return true }
 func (ViewGroupResponse) Cluster() zcl.ClusterID { return GroupsID }
 
 // Direction of the command
-func (ViewGroupResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (ViewGroupResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (ViewGroupResponse) MnfCode() uint16 { return 0 }
@@ -925,7 +925,7 @@ func (GetGroupMembershipResponse) Required() bool { return true }
 func (GetGroupMembershipResponse) Cluster() zcl.ClusterID { return GroupsID }
 
 // Direction of the command
-func (GetGroupMembershipResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (GetGroupMembershipResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (GetGroupMembershipResponse) MnfCode() uint16 { return 0 }
@@ -1038,7 +1038,7 @@ func (RemoveGroupResponse) Required() bool { return true }
 func (RemoveGroupResponse) Cluster() zcl.ClusterID { return GroupsID }
 
 // Direction of the command
-func (RemoveGroupResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (RemoveGroupResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (RemoveGroupResponse) MnfCode() uint16 { return 0 }

--- a/cluster/general/0005_scenes.go
+++ b/cluster/general/0005_scenes.go
@@ -1625,7 +1625,7 @@ func (AddSceneResponse) Required() bool { return true }
 func (AddSceneResponse) Cluster() zcl.ClusterID { return ScenesID }
 
 // Direction of the command
-func (AddSceneResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (AddSceneResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (AddSceneResponse) MnfCode() uint16 { return 0 }
@@ -1768,7 +1768,7 @@ func (ViewSceneResponse) Required() bool { return true }
 func (ViewSceneResponse) Cluster() zcl.ClusterID { return ScenesID }
 
 // Direction of the command
-func (ViewSceneResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (ViewSceneResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (ViewSceneResponse) MnfCode() uint16 { return 0 }
@@ -1932,7 +1932,7 @@ func (RemoveSceneResponse) Required() bool { return true }
 func (RemoveSceneResponse) Cluster() zcl.ClusterID { return ScenesID }
 
 // Direction of the command
-func (RemoveSceneResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (RemoveSceneResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (RemoveSceneResponse) MnfCode() uint16 { return 0 }
@@ -2059,7 +2059,7 @@ func (RemoveAllScenesResponse) Required() bool { return true }
 func (RemoveAllScenesResponse) Cluster() zcl.ClusterID { return ScenesID }
 
 // Direction of the command
-func (RemoveAllScenesResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (RemoveAllScenesResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (RemoveAllScenesResponse) MnfCode() uint16 { return 0 }
@@ -2175,7 +2175,7 @@ func (StoreSceneResponse) Required() bool { return true }
 func (StoreSceneResponse) Cluster() zcl.ClusterID { return ScenesID }
 
 // Direction of the command
-func (StoreSceneResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (StoreSceneResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (StoreSceneResponse) MnfCode() uint16 { return 0 }
@@ -2309,7 +2309,7 @@ func (GetSceneMembershipResponse) Required() bool { return true }
 func (GetSceneMembershipResponse) Cluster() zcl.ClusterID { return ScenesID }
 
 // Direction of the command
-func (GetSceneMembershipResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (GetSceneMembershipResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (GetSceneMembershipResponse) MnfCode() uint16 { return 0 }
@@ -2448,7 +2448,7 @@ func (EnhancedAddSceneResponse) Required() bool { return false }
 func (EnhancedAddSceneResponse) Cluster() zcl.ClusterID { return ScenesID }
 
 // Direction of the command
-func (EnhancedAddSceneResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (EnhancedAddSceneResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (EnhancedAddSceneResponse) MnfCode() uint16 { return 0 }
@@ -2591,7 +2591,7 @@ func (EnhancedViewSceneResponse) Required() bool { return false }
 func (EnhancedViewSceneResponse) Cluster() zcl.ClusterID { return ScenesID }
 
 // Direction of the command
-func (EnhancedViewSceneResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (EnhancedViewSceneResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (EnhancedViewSceneResponse) MnfCode() uint16 { return 0 }
@@ -2754,7 +2754,7 @@ func (CopySceneResponse) Required() bool { return false }
 func (CopySceneResponse) Cluster() zcl.ClusterID { return ScenesID }
 
 // Direction of the command
-func (CopySceneResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (CopySceneResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (CopySceneResponse) MnfCode() uint16 { return 0 }

--- a/cluster/general/0009_alarms.go
+++ b/cluster/general/0009_alarms.go
@@ -396,7 +396,7 @@ func (Alarm) Required() bool { return true }
 func (Alarm) Cluster() zcl.ClusterID { return AlarmsID }
 
 // Direction of the command
-func (Alarm) Direction() zcl.Direction { return zcl.ClientToServer }
+func (Alarm) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (Alarm) MnfCode() uint16 { return 0 }
@@ -514,7 +514,7 @@ func (GetAlarmResponse) Required() bool { return false }
 func (GetAlarmResponse) Cluster() zcl.ClusterID { return AlarmsID }
 
 // Direction of the command
-func (GetAlarmResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (GetAlarmResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (GetAlarmResponse) MnfCode() uint16 { return 0 }

--- a/cluster/general/000b_location.go
+++ b/cluster/general/000b_location.go
@@ -1209,7 +1209,7 @@ func (DeviceConfigurationResponse) Required() bool { return true }
 func (DeviceConfigurationResponse) Cluster() zcl.ClusterID { return LocationID }
 
 // Direction of the command
-func (DeviceConfigurationResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (DeviceConfigurationResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (DeviceConfigurationResponse) MnfCode() uint16 { return 0 }
@@ -1414,7 +1414,7 @@ func (LocationDataResponse) Required() bool { return true }
 func (LocationDataResponse) Cluster() zcl.ClusterID { return LocationID }
 
 // Direction of the command
-func (LocationDataResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (LocationDataResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (LocationDataResponse) MnfCode() uint16 { return 0 }
@@ -1680,7 +1680,7 @@ func (LocationDataNotification) Required() bool { return true }
 func (LocationDataNotification) Cluster() zcl.ClusterID { return LocationID }
 
 // Direction of the command
-func (LocationDataNotification) Direction() zcl.Direction { return zcl.ClientToServer }
+func (LocationDataNotification) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (LocationDataNotification) MnfCode() uint16 { return 0 }
@@ -1904,7 +1904,7 @@ func (CompactLocationDataNotification) Required() bool { return true }
 func (CompactLocationDataNotification) Cluster() zcl.ClusterID { return LocationID }
 
 // Direction of the command
-func (CompactLocationDataNotification) Direction() zcl.Direction { return zcl.ClientToServer }
+func (CompactLocationDataNotification) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (CompactLocationDataNotification) MnfCode() uint16 { return 0 }
@@ -2073,7 +2073,7 @@ func (RssiPing) Required() bool { return true }
 func (RssiPing) Cluster() zcl.ClusterID { return LocationID }
 
 // Direction of the command
-func (RssiPing) Direction() zcl.Direction { return zcl.ClientToServer }
+func (RssiPing) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (RssiPing) MnfCode() uint16 { return 0 }
@@ -2165,7 +2165,7 @@ func (RssiRequest) Required() bool { return false }
 func (RssiRequest) Cluster() zcl.ClusterID { return LocationID }
 
 // Direction of the command
-func (RssiRequest) Direction() zcl.Direction { return zcl.ClientToServer }
+func (RssiRequest) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (RssiRequest) MnfCode() uint16 { return 0 }
@@ -2244,7 +2244,7 @@ func (ReportRssiMeasurements) Required() bool { return false }
 func (ReportRssiMeasurements) Cluster() zcl.ClusterID { return LocationID }
 
 // Direction of the command
-func (ReportRssiMeasurements) Direction() zcl.Direction { return zcl.ClientToServer }
+func (ReportRssiMeasurements) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (ReportRssiMeasurements) MnfCode() uint16 { return 0 }
@@ -2461,7 +2461,7 @@ func (DistanceMeasureResponse) Required() bool { return true }
 func (DistanceMeasureResponse) Cluster() zcl.ClusterID { return LocationID }
 
 // Direction of the command
-func (DistanceMeasureResponse) Direction() zcl.Direction { return zcl.ClientToServer }
+func (DistanceMeasureResponse) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (DistanceMeasureResponse) MnfCode() uint16 { return 0 }

--- a/cluster/ias/0500_ias_zone.go
+++ b/cluster/ias/0500_ias_zone.go
@@ -372,7 +372,7 @@ func (ZoneStateChangeNotification) Required() bool { return false }
 func (ZoneStateChangeNotification) Cluster() zcl.ClusterID { return IasZoneID }
 
 // Direction of the command
-func (ZoneStateChangeNotification) Direction() zcl.Direction { return zcl.ClientToServer }
+func (ZoneStateChangeNotification) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (ZoneStateChangeNotification) MnfCode() uint16 { return 0 }
@@ -508,7 +508,7 @@ func (ZoneEnrollRequest) Required() bool { return false }
 func (ZoneEnrollRequest) Cluster() zcl.ClusterID { return IasZoneID }
 
 // Direction of the command
-func (ZoneEnrollRequest) Direction() zcl.Direction { return zcl.ClientToServer }
+func (ZoneEnrollRequest) Direction() zcl.Direction { return zcl.ServerToClient }
 
 // MnfCode returns the manufacturer code (if any) of the command
 func (ZoneEnrollRequest) MnfCode() uint16 { return 0 }

--- a/generator/gen.go
+++ b/generator/gen.go
@@ -91,12 +91,12 @@ func genHelpers(cluster *Cluster, zdo *Zdo, server bool, clusterID, pkg, tplPath
 		"direction": func(c Command) string {
 			if cluster != nil {
 				for _, cmd := range cluster.Server.Command {
-					if cmd.ID == c.ID {
+					if cmd.ID == c.ID && cmd.Name == c.Name {
 						return "ClientToServer"
 					}
 				}
 				for _, cmd := range cluster.Client.Command {
-					if cmd.ID == c.ID {
+					if cmd.ID == c.ID && cmd.Name == c.Name {
 						return "ServerToClient"
 					}
 				}


### PR DESCRIPTION
Fixes a bug where if same command ID exists both in server and client the direction will always be set to client-to-server